### PR TITLE
toy-board-10 조회 수 기능 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,6 +45,7 @@ dependencies {
     implementation("org.jetbrains.exposed:exposed-jdbc:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-kotlin-datetime:$exposedVersion")
     implementation("org.jetbrains.exposed:exposed-spring-boot-starter:$exposedVersion")
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
     // view
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     // https://github.com/wimdeblauwe/htmx-spring-boot

--- a/src/main/kotlin/org/antop/board/config/LocalDateTimeRedisSerializer.kt
+++ b/src/main/kotlin/org/antop/board/config/LocalDateTimeRedisSerializer.kt
@@ -1,0 +1,14 @@
+package org.antop.board.config
+
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.format
+import org.springframework.data.redis.serializer.RedisSerializer
+
+class LocalDateTimeRedisSerializer : RedisSerializer<LocalDateTime> {
+    override fun serialize(value: LocalDateTime?): ByteArray? = value?.format(LocalDateTime.Formats.ISO)?.toByteArray()
+
+    override fun deserialize(bytes: ByteArray?): LocalDateTime? =
+        bytes?.let {
+            LocalDateTime.parse(String(it), LocalDateTime.Formats.ISO)
+        }
+}

--- a/src/main/kotlin/org/antop/board/config/RedisConfig.kt
+++ b/src/main/kotlin/org/antop/board/config/RedisConfig.kt
@@ -1,0 +1,20 @@
+package org.antop.board.config
+
+import kotlinx.datetime.LocalDateTime
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.serializer.StringRedisSerializer
+
+@Configuration
+class RedisConfig {
+    @Bean
+    fun redisTemplate(redisConnectionFactory: RedisConnectionFactory): RedisTemplate<String, LocalDateTime> {
+        val redisTemplate = RedisTemplate<String, LocalDateTime>()
+        redisTemplate.connectionFactory = redisConnectionFactory
+        redisTemplate.keySerializer = StringRedisSerializer()
+        redisTemplate.valueSerializer = LocalDateTimeRedisSerializer()
+        return redisTemplate
+    }
+}

--- a/src/main/kotlin/org/antop/board/dto/PostDto.kt
+++ b/src/main/kotlin/org/antop/board/dto/PostDto.kt
@@ -6,4 +6,5 @@ data class PostDto(
     val content: String,
     val author: String,
     val changeAt: String,
+    val hits: Long,
 )

--- a/src/main/kotlin/org/antop/board/extensions/ValueOperations.kt
+++ b/src/main/kotlin/org/antop/board/extensions/ValueOperations.kt
@@ -1,0 +1,16 @@
+package org.antop.board.extensions
+
+import org.springframework.data.redis.core.ValueOperations
+import java.util.concurrent.TimeUnit
+
+/**
+ * 코틀린 문법으로 `[key, timeout, unit] = value`를 사용할 수 있도록 해주는 확장 함수
+ */
+operator fun <K : Any, V : Any> ValueOperations<K, V>.set(
+    key: K,
+    timeout: Long,
+    unit: TimeUnit,
+    value: V,
+) {
+    this[key, value, timeout] = unit
+}

--- a/src/main/kotlin/org/antop/board/model/Post.kt
+++ b/src/main/kotlin/org/antop/board/model/Post.kt
@@ -28,4 +28,7 @@ class Post(
     /** 마지막 변경일시 */
     val changeAt: LocalDateTime
         get() = modifiedAt ?: createdAt
+
+    /** 조회수 */
+    var hits by Posts.hits
 }

--- a/src/main/kotlin/org/antop/board/model/Posts.kt
+++ b/src/main/kotlin/org/antop/board/model/Posts.kt
@@ -9,4 +9,5 @@ object Posts : LongIdTable(name = "posts", columnName = "post_id") {
     val author = varchar("author", 100)
     val createdAt = datetime("created")
     val modifiedAt = datetime("modified").nullable()
+    val hits = long("hits").default(0L)
 }

--- a/src/main/kotlin/org/antop/board/service/PostHitsService.kt
+++ b/src/main/kotlin/org/antop/board/service/PostHitsService.kt
@@ -1,0 +1,51 @@
+package org.antop.board.service
+
+import kotlinx.datetime.LocalDateTime
+import org.antop.board.dto.PostDto
+import org.antop.board.extensions.now
+import org.antop.board.extensions.set
+import org.antop.board.model.Post
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.concurrent.TimeUnit
+
+@Service
+class PostHitsService(
+    private val redisTemplate: RedisTemplate<String, LocalDateTime>,
+) {
+    /**
+     * 조회 수 증가
+     *
+     * @param post 게시글 DTO
+     * @param visitorId 식별자 (IP 등)
+     * @return 증가된(또는 증가 안된) 조회 수
+     */
+    @Transactional
+    fun incrementHits(
+        post: PostDto,
+        visitorId: String,
+    ): Long {
+        val key = makeKey(post.id, visitorId)
+        return redisTemplate.opsForValue()[key]?.run {
+            post.hits
+        } ?: run {
+            val updated =
+                Post
+                    // select for update
+                    .findByIdAndUpdate(post.id) {
+                        // 조회수 증가
+                        it.hits++
+                        // 조회수 증가 후 24시간 동안 조회 수 증가 안됨
+                        redisTemplate.opsForValue()[key, 1, TimeUnit.DAYS] = LocalDateTime.now()
+                    }
+            updated?.hits ?: post.hits
+        }
+    }
+
+    /** 레디스 키 만들기 */
+    private fun makeKey(
+        id: Long,
+        visitorId: String,
+    ): String = "post:$id:$visitorId"
+}

--- a/src/main/kotlin/org/antop/board/service/PostService.kt
+++ b/src/main/kotlin/org/antop/board/service/PostService.kt
@@ -106,5 +106,6 @@ class PostService {
             content = post.content,
             author = post.author,
             changeAt = post.changeAt.pretty(),
+            hits = post.hits,
         )
 }

--- a/src/main/resources/templates/posts/list.html
+++ b/src/main/resources/templates/posts/list.html
@@ -19,6 +19,7 @@
             <th>번호</th>
             <th>제목</th>
             <th>작성자</th>
+            <td>조회수</td>
             <th>변경일시</th>
         </tr>
         </thead>
@@ -36,6 +37,7 @@
                        th:text="${item.data.subject}"></a>
                 </td>
                 <td th:text="${item.data.author}"></td>
+                <td th:text="${item.data.hits}"></td>
                 <td th:text="${item.data.changeAt}"></td>
             </tr>
         </th:block>

--- a/src/main/resources/templates/posts/view.html
+++ b/src/main/resources/templates/posts/view.html
@@ -16,6 +16,9 @@
     <div>작성자 :
         <th:block th:text="${post.author}"/>
     </div>
+    <div>조회수 :
+        <th:block th:text="${post.hits}"/>
+    </div>
     <div>마지막 수정 :
         <th:block th:text="${post.changeAt}"/>
     </div>


### PR DESCRIPTION
조회 수 기능 추가

1. 조회 수 컬럼 추가
2. 조회수 중복 방지 레디스를 사용
3. 비관적 락(`select * from posts where post_id = #{id} for update`)을 사용하여 조회수 증가