### PR TITLE
toy-board-25 게시글 조회 버그 수정

### DIFF
--- a/src/main/kotlin/org/antop/board/post/service/PostService.kt
+++ b/src/main/kotlin/org/antop/board/post/service/PostService.kt
@@ -19,6 +19,7 @@ import org.antop.board.post.model.PostFiles
 import org.antop.board.post.model.Posts
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SizedIterable
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.or
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -35,7 +36,7 @@ class PostService {
         pageSize: Int,
     ): Pagination.Response<PostDto> {
         val total = countQuery(keyword)
-        val posts = if (total > 0) selectClause(keyword, page, pageSize) else listOf()
+        val posts = if (total > 0) selectQuery(keyword, page, pageSize) else listOf()
         return Pagination.Response(
             items = posts.map { it.toDtoForList() },
             total = total,
@@ -49,7 +50,7 @@ class PostService {
             .withDistinct()
             .count()
 
-    private fun selectClause(
+    private fun selectQuery(
         keyword: String?,
         page: Long,
         pageSize: Int,
@@ -58,6 +59,7 @@ class PostService {
             .select(Posts.fields)
             .where { createOp(keyword) }
             .withDistinct()
+            .orderBy(Posts.id to SortOrder.DESC)
             .offset((page - 1) * pageSize)
             .limit(pageSize)
             .map { Post.wrapRow(it) }

--- a/src/main/kotlin/org/antop/board/post/service/PostService.kt
+++ b/src/main/kotlin/org/antop/board/post/service/PostService.kt
@@ -17,11 +17,9 @@ import org.antop.board.post.mapper.toDtoForList
 import org.antop.board.post.model.Post
 import org.antop.board.post.model.PostFiles
 import org.antop.board.post.model.Posts
-import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.or
-import org.jetbrains.exposed.sql.selectAll
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -36,7 +34,7 @@ class PostService {
         page: Long,
         pageSize: Int,
     ): Pagination.Response<PostDto> {
-        val total = countClause(keyword)
+        val total = countQuery(keyword)
         val posts = if (total > 0) selectClause(keyword, page, pageSize) else listOf()
         return Pagination.Response(
             items = posts.map { it.toDtoForList() },
@@ -44,10 +42,11 @@ class PostService {
         )
     }
 
-    fun countClause(keyword: String?): Long =
+    private fun countQuery(keyword: String?): Long =
         joinClause()
-            .selectAll()
+            .select(Posts.id)
             .where { createOp(keyword) }
+            .withDistinct()
             .count()
 
     private fun selectClause(
@@ -58,14 +57,15 @@ class PostService {
         joinClause()
             .select(Posts.fields)
             .where { createOp(keyword) }
+            .withDistinct()
             .offset((page - 1) * pageSize)
             .limit(pageSize)
             .map { Post.wrapRow(it) }
 
     private fun joinClause() =
         Posts
-            .join(PostFiles, JoinType.LEFT, additionalConstraint = { Posts.id eq PostFiles.post })
-            .join(Files, JoinType.LEFT, additionalConstraint = { PostFiles.file eq Files.id })
+            .leftJoin(PostFiles)
+            .leftJoin(Files)
 
     private fun createOp(keyword: String?) =
         keyword?.let {


### PR DESCRIPTION
게시글과 파일의 관계가 `N:M` 인 상태. 검색 시에 파일명으로도 검색을 하기위하여 `left join`으로 검색하게 되면서 카티션 프로덕트(Cartesian Product) 현상이 일어남.

`distinct`로 해결.

Closes #25 