### PR TITLE
toy-board-81 CSS 클래스명 충돌 (Prism, view.css)

### DIFF
--- a/src/main/resources/static/css/posts/view.css
+++ b/src/main/resources/static/css/posts/view.css
@@ -1,6 +1,6 @@
 @import "../common.css";
 
-.tag {
+.tags > .tag {
     padding: 5px 6px 4px 6px;
     border-radius: 4px;
     background: #F5F5F5;

--- a/src/main/resources/templates/posts/view/view.html
+++ b/src/main/resources/templates/posts/view/view.html
@@ -62,7 +62,7 @@
         <div class="mt-4 content ck-content">
             <th:block th:utext="${post.content}"/>
         </div>
-        <div class="mt-4" th:if="${post.tags != null}">
+        <div class="mt-4 tags" th:if="${post.tags != null}">
             <i class="bi bi-tag"></i>
             <a class="tag me-1" th:each="tag : ${post.tags}" th:href="@{/posts/list.html(keyword=${tag})}"
                th:text="'#' + ${tag}"/>


### PR DESCRIPTION
`.tags > .tag` 클래스로 처리

<img width="1631" alt="image" src="https://github.com/user-attachments/assets/4015ddbf-6eba-4418-a5b6-de4887a13418" />

Closes #81 