### PR TITLE
toy-board-86 이미 존재하는 이메일로 회원 가입 시 에러 처리

### DIFF
--- a/src/main/kotlin/org/antop/board/common/exceptions/EmailAlreadyExistsException.kt
+++ b/src/main/kotlin/org/antop/board/common/exceptions/EmailAlreadyExistsException.kt
@@ -1,0 +1,7 @@
+package org.antop.board.common.exceptions
+
+import jakarta.validation.ValidationException
+
+class EmailAlreadyExistsException(
+    val email: String,
+) : ValidationException("이미 존재하는 이메일입니다.")

--- a/src/main/kotlin/org/antop/board/member/service/MemberService.kt
+++ b/src/main/kotlin/org/antop/board/member/service/MemberService.kt
@@ -1,6 +1,7 @@
 package org.antop.board.member.service
 
 import kotlinx.datetime.LocalDateTime
+import org.antop.board.common.exceptions.EmailAlreadyExistsException
 import org.antop.board.common.extensions.now
 import org.antop.board.member.dto.MemberDto
 import org.antop.board.member.exception.MemberNotFoundException
@@ -36,13 +37,16 @@ class MemberService(
         password: String,
         nickname: String,
     ): MemberDto {
-        val entity =
+        memberRepository.findByEmail(email)?.let {
+            throw EmailAlreadyExistsException(email)
+        }
+        val member =
             Member.new {
                 this.email = email
                 this.password = passwordEncoder.encode(password)
                 this.nickname = nickname
                 created = LocalDateTime.now()
             }
-        return entity.toDto()
+        return member.toDto()
     }
 }


### PR DESCRIPTION
아래와 같이 응답이 오도록 함.

```json
{
    "timestamp": "2025-05-01T05:31:04.974+00:00",
    "status": 400,
    "error": "Bad Request",
    "exception": "org.antop.board.common.exceptions.EmailAlreadyExistsException",
    "message": "이미 존재하는 이메일입니다.",
    "path": "/members/register"
}
```

Closes #86 